### PR TITLE
Add details of Rocket database_url to install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,7 +96,9 @@ environment variable so `diesel` will know how to connect to postgres:
 
 Fill in your own values for `username`, `password`, `host`, and `port`. You also
 don't *have* to call the database `fedibook_development`, but that is
-standard.
+standard. For local development this will likely look something like:
+
+    export DATABASE_URL="postgres://aardwolf:password@localhost/aardwolf_development"
 
 Next, run the follow to create the database:
 
@@ -105,6 +107,9 @@ Next, run the follow to create the database:
 If this command succeeded, run the migrations:
 
     $ diesel migration run
+
+Edit `Rocket.toml` and update the `database_url` with the same value used for
+the `DATABASE_URL` environment variable above.
 
 ## Running the server
 


### PR DESCRIPTION
This tripped me up when I tried running it as I thought I'd already dealt with the DB config in the `DATABASE_URL` env var. Add a note that you have to set the key in the `Rocket.toml` too so other don't get tripped up.