### PR TITLE
Add setup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ path = "src/aardwolf/lib.rs"
 name = "aardwolf-server"
 path = "src/bin/main.rs"
 
+[[bin]]
+name = "setup"
+path = "src/bin/setup.rs"
+
 [dependencies]
 bs58 = "0.2"
 bcrypt = "0.1"
@@ -28,6 +32,7 @@ serde = "1.0.21"
 serde_derive = "1.0.21"
 config = "0.7.0"
 clap = {version = "2.29", features = ["yaml"]}
+yaml-rust = "0.3.5"
 
 [dependencies.chrono]
 version = "0.4"

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+use std::env;
+
+use clap::App;
+use config::{self, Config};
+
+pub fn configure(app: App) -> Config {
+    // Set defaults
+    let mut config = Config::default();
+    config.set_default::<&str>("cfg_file", concat!(env!("CARGO_PKG_NAME"), ".toml")).unwrap();
+    config.set_default::<&str>("log_file", concat!(env!("CARGO_PKG_NAME"), ".log")).unwrap();
+    config.set_default::<&str>("Web.Listen.address", "127.0.0.1").unwrap();
+    config.set_default("Web.Listen.port", 7878).unwrap();
+
+    // Parse arguments
+    let args = app.get_matches();
+
+    // Determine config file
+    // TODO: Is there a better way to handle this?
+    match env::var("AARDWOLF_CONFIG") {
+        Ok(c) => {config.set("cfg_file", c).unwrap();},
+        Err(_) => {}
+    }
+
+    match args.value_of("config") {
+        Some(c) => {config.set("cfg_file", c).unwrap();},
+        None => {}
+    }
+
+    // Merge config file and apply over-rides
+    let cfg_file: PathBuf = PathBuf::from(config.get_str("cfg_file").unwrap());
+    config.merge(config::File::with_name(cfg_file.to_str().unwrap())).unwrap();
+
+    //  TODO: Is there a better way to handle this?
+    match env::var("AARDWOLF_LOG") {
+        Ok(l) => {config.set("log_file", l).unwrap();},
+        Err(_) => {}
+    }
+
+    match args.value_of("log") {
+        Some(l) => {config.set("log_file", l).unwrap();},
+        None => {}
+    }
+
+    config
+}
+
+pub fn db_conn_str(config: &Config) -> String {
+    let scheme = match config.get_str("Database.type").unwrap().to_lowercase().as_str() {
+        "postgresql" | "postgres" => "postgres",
+
+        // If we reach this case, it's an error.
+        // TODO: Handle it better.
+        _ => panic!("Unsupported scheme, only `postgres' and `postgresql` are supported"),
+    };
+
+    format!("{scheme}://{username}:{password}@{host}:{port}/{database}",
+            scheme=scheme,
+            username=config.get_str("Database.username").expect("Missing key Database.username").as_str(),
+            password=config.get_str("Database.password").expect("Missing key Database.password").as_str(),
+            host=config.get_str("Database.host").expect("Missing key Database.host").as_str(),
+            port=config.get_str("Database.port").expect("Missing key Database.port").as_str(),
+            database=config.get_str("Database.database").expect("Missing key Database.database").as_str())
+}

--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -17,14 +17,12 @@ pub fn configure(app: App) -> Config {
 
     // Determine config file
     // TODO: Is there a better way to handle this?
-    match env::var("AARDWOLF_CONFIG") {
-        Ok(c) => {config.set("cfg_file", c).unwrap();},
-        Err(_) => {}
+    if let Ok(c) = env::var("AARDWOLF_CONFIG") {
+        config.set("cfg_file", c).expect("failed to set cfg_file from the environment variable AARDWOLF_CONFIG");
     }
 
-    match args.value_of("config") {
-        Some(c) => {config.set("cfg_file", c).unwrap();},
-        None => {}
+    if let Some(c) = args.value_of("config") {
+        config.set("cfg_file", c).expect("failed to set cfg_file from the --config argument");
     }
 
     // Merge config file and apply over-rides
@@ -32,14 +30,12 @@ pub fn configure(app: App) -> Config {
     config.merge(config::File::with_name(cfg_file.to_str().unwrap())).unwrap();
 
     //  TODO: Is there a better way to handle this?
-    match env::var("AARDWOLF_LOG") {
-        Ok(l) => {config.set("log_file", l).unwrap();},
-        Err(_) => {}
+    if let Ok(l) = env::var("AARDWOLF_LOG") {
+        config.set("log_file", l).expect("failed to set log_file from the environment variable AARDWOLF_LOG");
     }
 
-    match args.value_of("log") {
-        Some(l) => {config.set("log_file", l).unwrap();},
-        None => {}
+    if let Some(l) = args.value_of("log") {
+        config.set("log_file", l).expect("failed to set log_file from the --log argument");
     }
 
     config

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,10 +24,7 @@ use rocket::Rocket;
 use rocket_contrib::Template;
 use diesel::pg::PgConnection;
 use r2d2_diesel::ConnectionManager;
-use config::Config;
 use clap::App;
-use std::path::PathBuf;
-use std::env;
 
 mod common;
 

--- a/src/bin/setup.rs
+++ b/src/bin/setup.rs
@@ -1,0 +1,45 @@
+#[macro_use] extern crate clap;
+extern crate config;
+
+use std::error::Error as StdError;
+use std::io::ErrorKind;
+use std::process::{self, Command};
+
+use clap::App;
+
+mod common;
+
+fn main() {
+    let yaml = load_yaml!("setup.yml");
+    let app = App::from_yaml(yaml)
+        .version(env!("CARGO_PKG_VERSION"))
+        .author(env!("CARGO_PKG_AUTHORS"));
+    let config = common::configure(app);
+    let db_url = common::db_conn_str(&config);
+    println!("using database url `{}' to setup the aardwolf database", &db_url);
+    let output = Command::new("diesel")
+        .arg("setup")
+        .env("DATABASE_URL", &db_url)
+        .output();
+    if let Err(e) = output {
+        match e.kind() {
+            ErrorKind::NotFound => {
+                eprintln!("Could not find `diesel` binary, please use `cargo install diesel_cli` to install it");
+            },
+            _ => eprintln!("got error {}", e.description()),
+        }
+        process::exit(255);
+    }
+    println!("database successfully set up, running migrations");
+    let output = Command::new("diesel")
+        .arg("migration")
+        .arg("run")
+        .env("DATABASE_URL", &db_url)
+        .output();
+    if let Err(e) = output {
+        eprintln!("got error {}", e.description());
+        process::exit(255);
+    }
+    println!("database migrations were successfully run, you're ready to go!");
+}
+

--- a/src/bin/setup.yml
+++ b/src/bin/setup.yml
@@ -1,0 +1,16 @@
+name: aardwolf-setup
+version: unknown
+author: Please see README for credits
+about: development setup utility
+args:
+    - config:
+        short: c
+        long: config
+        value_name: CFG_FILE
+        help: Sets a custom config file
+        takes_value: true
+    - verbose:
+        short: v
+        multiple: true
+        help: Sets the level of verbosity
+


### PR DESCRIPTION
This should eliminate the need to set `DATABASE_URL` or use the `diesel` command when a developer is getting up-and-running

Instead of having to run

```
$ DATABASE_URL=foobar diesel setup
$ DATABASE_URL=foobar diesel migration run
```

with this you just run

```
$ cargo run --bin setup
```

and it should take care of the db for you.