### PR TITLE
Add Fedora install instructions for postgresql

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,10 @@ For Gentoo (eselect-postgresql is optional),
     # emerge --sync
     # emerge -av postgresql eselect-postgresql
 
+For Fedora/CentOS/RHEL, do
+
+    # dnf install postgresql-server postgresql-contrib
+
 #### Windows Instructions
 
 For Windows, just download the installer [here](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows) and run it. After installing, make sure to add the <POSTGRES INSTALL PATH>/lib directory to your PATH system variable.


### PR DESCRIPTION
So, this is just a little note added to the INSTALL.md that tells Fedora/CentOS/RHEL users which postgresql packages they need, because in my experience, people won't install postgresql-contrib unless they're specifically told they need to.