### PR TITLE
Remove /web and /auth prefixes from routes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,65 @@ Contributors are always welcome! We are looking for help from technical and non-
 - Most of the core contributors use Riot/Matrix room [#aardwolf-discussion:matrix.org](https://riot.im/app/#/room/#aardwolf-discussion:matrix.org)
 - You can also join the [aardwolf-development mailing list](https://lists.riseup.net/www/info/aardwolf-development).
 - @-Mentioning someone here will also receive a prompt response.
+=======
+# Contributing to aardwolf
+
+Contributors are always welcome! Hopefully this guide will provide some pointers :D
+
+## Getting started
+
+High level approach:
+
+1. Find something to fix/improve
+2. Change code (Rust code lives in /src/, WebUI lives in /templates/`)
+3. Run the app to verify (cargo run --bin aardwolf-server), make changes until it works
+4. Open a PR (also can be done between 2. and 3. if you run into problems)
+
+## Contributions
+
+All contributions to Aardwolf or its dependencies should be made in the form of GitHub
+pull requests (PR's). Each pull request will be reviewed by a core contributor
+(someone with permission to merge PR's) and either merged in the main tree or
+given feedback for changes that would be required. All contributions should
+follow this format, even those from core contributors.
+
+Should you wish to work on an issue, please claim it first by commenting on
+the GitHub issue that you want to work on it. This is to prevent duplicated
+efforts from contributors on the same issue.
+
+Head over to [Aardwolf Starter Issues](TBD) to find good tasks to start with. 
+If you come across words or jargon that do not make sense, please feel free to ask. 
+We will probably be working on a proper glossary at some point after get a proper 
+application running. 
+
+## Pull Request Checklist
+
+- Branch from the master branch and, if needed, rebase to the current master
+  branch before submitting your pull request. If it doesn't merge cleanly with
+  master you may be asked to rebase your changes.
+
+- Commits should be as small as possible, while ensuring that each commit is
+  correct independently (i.e., each commit should compile and pass tests). 
+
+- If your patch is not getting reviewed or you need a specific person to review
+  it, you can @-reply a reviewer asking for a review in the pull request or a
+  comment, or you can ask for a review in [#aardwolf-discussion:matrix.org](https://riot.im/app/#/room/#aardwolf-discussion:matrix.org)
+  or the mailing list `aardwolf-development@lists.riseup.net`.
+
+- Add tests relevant to the fixed bug or new feature.  For a DOM change this
+  will usually be a web platform test; for layout, a reftest.  See our [testing
+  guide](https://github.com/servo/servo/wiki/Testing) for more information.
+
+For specific git instructions, see [GitHub workflow 101](https://github.com/servo/servo/wiki/Github-workflow).
+(( Yes this links to a different repo but I like how it reads so :P ))
+
+## Conduct
+
+Please be mindful of our [Code of Conduct](CODE_OF_CONDUCT)
+
+## Communication
+
+Most of the core contributors are on Riot/Matrix room [#aardwolf-discussion:matrix.org](https://riot.im/app/#/room/#aardwolf-discussion:matrix.org)
+
+You can also join the [`aardwolf-development` mailing list](https://lists.riseup.net/www/info/aardwolf-development).
+

--- a/src/README.md
+++ b/src/README.md
@@ -82,19 +82,19 @@ already installed, the workflow goes like this:
   * When you see "Rocket has launched from http://...." you should be
     able to connect to the running app
   * Assuming you run the app on `localhost` and use the `7878` port, you
-    can browse to `http://localhost:7878/auth/sign_up` and register a
+    can browse to `http://localhost:7878/sign_up` and register a
     user account
   * If the registration succeeds, it will redirect you to
-    `http://localhost:7878/auth/sign_in`. You won't actually be able to
+    `http://localhost:7878/sign_in`. You won't actually be able to
     sign in yet, you have to confirm your account.
   * Go back to the command line, you should see a message that has a
     path at the end with the token to confirm your account.
   * Go to `http://localhost:7878<the path from the console>` in your
     browser
   * If the confirmation succeeded, it should redirect you back to the
-    `/auth/sign_in` page, where you should be able to log in now.
-  * If the log in succeeds, it should redirect you to `/web` and show
+    `/sign_in` page, where you should be able to log in now.
+  * If the log in succeeds, it should redirect you to `/` and show
     you a message, and a "logout" button
 
-Going to `/web` without logging in should redirect you to the login page
+Going to `/` without logging in should redirect you to the login page
 

--- a/src/aardwolf/controllers/auth.rs
+++ b/src/aardwolf/controllers/auth.rs
@@ -63,7 +63,7 @@ pub(crate) fn create_user_and_account<T: SecureRandom>(form: SignUpForm, gen: &T
 
     // just printing this out for now so we can copy/paste into the browser to confirm accounts,
     // but obviously this will need to be emailed to the user
-    println!("confirmation token url: /auth/confirmation?token={}", &strtoken);
+    println!("confirmation token url: /confirmation?token={}", &strtoken);
 
     Ok(())
 }

--- a/src/aardwolf/routes/app.rs
+++ b/src/aardwolf/routes/app.rs
@@ -4,7 +4,7 @@ use rocket_contrib::Template;
 use models::user::User;
 use DbConn;
 
-#[get("/web")]
+#[get("/")]
 fn home(user: User, _db: DbConn) -> Template {
     let map = hashmap!{
         "email" => user.email,
@@ -12,17 +12,7 @@ fn home(user: User, _db: DbConn) -> Template {
     Template::render("home", map)
 }
 
-#[get("/web", rank = 2)]
+#[get("/", rank = 2)]
 fn home_redirect() -> Redirect {
-    Redirect::to("/auth/sign_in")
-}
-
-// Adding route to /
-#[get("/")]
-fn index() -> &'static str {
-     "
-      This is Banjo's Dummy Index because he's not sure how to use Template::render yet
-      ...
-      Soon though...maybe?
-    "
+    Redirect::to("/sign_in")
 }

--- a/src/aardwolf/routes/auth.rs
+++ b/src/aardwolf/routes/auth.rs
@@ -14,13 +14,13 @@ struct SignUpError {
     msg: String
 }
 
-#[get("/auth/sign_up?<error>")]
+#[get("/sign_up?<error>")]
 fn sign_up_form_with_error(error: SignUpError) -> Template {
     let token = "some csrf token";
     Template::render("sign_up", hashmap!{ "token" => token, "error_msg" => error.msg.as_str() })
 }
 
-#[get("/auth/sign_up")]
+#[get("/sign_up")]
 fn sign_up_form() -> Template {
     let token = "some csrf token";
     Template::render("sign_up", hashmap!{ "token" => token })
@@ -31,32 +31,32 @@ struct SignInError {
     msg: String
 }
 
-#[get("/auth/sign_in?<error>")]
+#[get("/sign_in?<error>")]
 fn sign_in_form_with_error(error: SignInError) -> Template {
     let token = "some csrf token";
     Template::render("sign_in", hashmap!{ "token" => token, "error_msg" => error.msg.as_str() })
 }
 
-#[get("/auth/sign_in")]
+#[get("/sign_in")]
 fn sign_in_form() -> Template {
     let token = "some csrf token";
     Template::render("sign_in", hashmap!{ "token" => token })
 }
 
-#[post("/auth", data = "<form>")]
+#[post("/sign_up", data = "<form>")]
 fn sign_up(form: Form<SignUpForm>, gen: State<SystemRandom>, db: DbConn) -> Redirect {
     use controllers::auth;
 
     match auth::create_user_and_account(form.into_inner(), gen.inner(), &db) {
-        Ok(_) => Redirect::to("/auth/sign_in"),
+        Ok(_) => Redirect::to("/sign_in"),
         Err(e) => {
             println!("unable to create account: {:#?}", e);
-            Redirect::to(&format!("/auth/sign_up?msg={}", e))
+            Redirect::to(&format!("/sign_up?msg={}", e))
         }
     }
 }
 
-#[post("/auth/sign_in", data = "<form>")]
+#[post("/sign_in", data = "<form>")]
 fn sign_in(form: Form<SignInForm>, db: DbConn, mut cookies: Cookies) -> Redirect {
     use controllers::auth;
     match auth::sign_in(&form.into_inner(), &db) {
@@ -64,11 +64,11 @@ fn sign_in(form: Form<SignInForm>, db: DbConn, mut cookies: Cookies) -> Redirect
             let mut cookie = Cookie::new("user_id", user.id.to_string());
             cookie.set_http_only(true);
             cookies.add_private(cookie);
-            Redirect::to("/web")
+            Redirect::to("/")
         },
         Err(e) => {
             println!("unable to log in: {:#?}", e);
-            Redirect::to(&format!("/auth/sign_in?msg={}", e))
+            Redirect::to(&format!("/sign_in?msg={}", e))
         }
     }
 }
@@ -82,12 +82,12 @@ struct ConfirmToken {
 #[fail(display = "Failed to confirm account")]
 struct ConfirmError;
 
-#[get("/auth/confirmation?<token>")]
+#[get("/confirmation?<token>")]
 fn confirm(token: ConfirmToken, db: DbConn) -> Result<Redirect, ConfirmError> {
     use controllers::auth;
 
     Ok(match auth::confirm_account(&token.token, &db) {
-        Ok(_) => Redirect::to("/auth/sign_in"),
+        Ok(_) => Redirect::to("/sign_in"),
         Err(e) => {
             println!("unable to confirm account: {:#?}", e);
             return Err(ConfirmError);
@@ -95,8 +95,8 @@ fn confirm(token: ConfirmToken, db: DbConn) -> Result<Redirect, ConfirmError> {
     })
 }
 
-#[post("/auth/sign_out")]
+#[post("/sign_out")]
 fn sign_out(_user: User, mut cookies: Cookies) -> Redirect {
     cookies.remove_private(Cookie::named("user_id"));
-    Redirect::to("/auth/sign_in")
+    Redirect::to("/sign_in")
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -61,9 +61,6 @@ fn app(config: config::Config) -> Rocket {
 
             aardwolf::routes::app::home,
             aardwolf::routes::app::home_redirect,
-
-            // Adding route to / 
-            aardwolf::routes::app::index,
         ])
         .attach(Template::fairing())
         .manage(SystemRandom::new());

--- a/templates/home.html.hbs
+++ b/templates/home.html.hbs
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <body>
-    <form method="post" action="/auth/sign_out">
+    <form method="post" action="/sign_out">
         <button type="submit">Logout</button>
     </form>
     <p>Welcome, {{ email }}</p>

--- a/templates/http_error.html
+++ b/templates/http_error.html
@@ -19,7 +19,7 @@
         Something has gone <strong class="tag is-danger">horribly wrong</strong>
       </p>
       <figure>
-        <img src="../web/images/aardwolf-error.jpg" width="256" height="256"alt="Error">
+        <img src="../images/aardwolf-error.jpg" width="256" height="256"alt="Error">
       </figure>
     </div>
   </section>

--- a/templates/main-demo.html
+++ b/templates/main-demo.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
   <!-- This is a hacky CSS that really needs to be fixed/replaced. I'm just putting it here to see if I can improve the styling until proper Bulma implementation -->
-  <link rel="stylesheet" media="screen" href="../web/stylesheets/scratchpad.css">
+  <link rel="stylesheet" media="screen" href="../stylesheets/scratchpad.css">
 </head>
 
 <body>

--- a/templates/main.html.hbs
+++ b/templates/main.html.hbs
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.1/css/bulma.min.css">
     <!-- This is a hacky CSS that really needs to be fixed/replaced. I'm just putting it here to see if I can improve the styling until proper Bulma implementation -->
-    <link rel="stylesheet" media="screen" href="../web/stylesheets/scratchpad.css">
+    <link rel="stylesheet" media="screen" href="../stylesheets/scratchpad.css">
   </head>
   <body>
 

--- a/templates/main_nav_top.html.hbs
+++ b/templates/main_nav_top.html.hbs
@@ -2,7 +2,7 @@
   <div class="container">
 	<div class="navbar-brand">
 	  <a class="navbar-item">
-		<img src="../web/images/aardwolf-logo.jpg" alt="Aardwolf">
+		<img src="../images/aardwolf-logo.jpg" alt="Aardwolf">
 	  </a>
 	  <span class="navbar-burger burger" data-target="navbarMenuHeroA">
 		<span></span>

--- a/templates/sign_in.html.hbs
+++ b/templates/sign_in.html.hbs
@@ -45,7 +45,7 @@
         Welcome back!
       </p>
 	  <span style="color: red;">{{ error_msg }}</span>
-	  <form method="POST" action="/auth/sign_in">
+	  <form method="POST" action="/sign_in">
 	 	 <input type="hidden" name="csrf_token" value="{{ token }}">
 		 <input type="email" name="email" id="email" placeholder="E-mail address">
 		 <input type="password" name="password" id="password" placeholder="Password">

--- a/templates/sign_up.html.hbs
+++ b/templates/sign_up.html.hbs
@@ -45,7 +45,7 @@
         Feel free to sign up!
       </p>
     <span style="color: red;">{{ error_msg }}</span>
-	  <form method="POST" action="/auth">
+	  <form method="POST" action="/sign_up">
 		<input type="hidden" name="csrf_token" value="{{ token }}">
 		<span class="icon icon-user"></span>
 		<input type="text" name="username" id="username" placeholder="username@aardwolf.social">


### PR DESCRIPTION
This is work towards #69, but only modifying the existing routes.

- Remove /web and /auth prefixes from routes.
- Also updated links to static files in templates, but these files are not served yet.
- Remove index route, use / for home route.
- Move sign-up form data post location to /sign_up.