### PR TITLE
fixed some typos and links on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Greetings friend! 
 :tada: Guten Tag! :balloon: Cześć! :sparkles: Здравствуйте! :star2: こんにちは! :bow:
 
-If you are unfamiliar with GitHub (nice to have you here!), the document you are reading currently is the main README.md, and serves as a general index Aardwolf Project.  
+If you are unfamiliar with GitHub (nice to have you here!), the document you are reading currently is the main README.md, and serves as a general index for the Aardwolf Project.  
 
 Please feel free to look around, ask questions, and leave comments. We gladly welcome community participation while we grow, and expand.  
 Use the list below to jump to a specific section, or simply scroll down.
@@ -37,10 +37,10 @@ Our vision is to create a social-networking platform that mirrors the functional
 ### Who are we?
 We are a group of friends that met on Mastodon to collaborate on building a better social networking application.  Despite our busy lives we are all able to share our multitude of talents with one another to bring this project to life, one small contribution at a time.  While the core group have years of development experience, several of them have not used Rust until this project.  Others, such as Banjo, have never done any significant development work, but are able to take on other responsibilities such as project management, documentation, or even creating artwork (yes there is plenty of non-technical work that needs doing ;D).
 
-Banjo is currently working as an Information Security Engineer, but his primary background is in computer hardware, and Linux system administration.  He can usually be found elbows deep in some project or another, be it home DIY, planning or making beer/mead, fishing, or gaming.  To date, Aardwolf is also the first development project he has ever managed, but is having a lot of fun, and learning a heck of a lot about web applications get built.  Someday he hopes to have enough "free time" to go back to learning Rust.
+Banjo is currently working as an Information Security Engineer, but his primary background is in computer hardware, and Linux system administration.  He can usually be found elbows deep in some project or another, be it home DIY, planning or making beer/mead, fishing, or gaming.  To date, Aardwolf is also the first development project he has ever managed, but he is having a lot of fun, and learning a heck of a lot about how web applications get built.  Someday he hopes to have enough "free time" to go back to learning Rust.
 
 ###  What do we need?
-There are a lot of moving pieces right now, but this list should remain relatively stable.  In -all- cases we are NOT looking for expert developers.  Even if you are **new** to any of the topics below thats okay!  For a lot of us this is a learning experience, and we like to help each other out.  Do not be afraid to ask :)
+There are a lot of moving pieces right now, but this list should remain relatively stable.  In -all- cases we are NOT looking for expert developers.  Even if you are **new** to any of the topics below that's okay!  For a lot of us this is a learning experience, and we like to help each other out.  Do not be afraid to ask :)
 
   _ProTip: Working on a project is a great way to learn programming ;)_
 
@@ -55,7 +55,7 @@ There are a lot of moving pieces right now, but this list should remain relative
 ### Get involved
 If you think you can help in any of the areas listed above (and we bet you can) or in any of the many areas that we haven't yet thought of (and here we're sure you can) then please check out our contributors' guidelines and our roadmap.
 
-Please note that it's very important to us that we maintain a positive and supportive environment for everyone who wants to participate. When you join us we ask that you follow our code of conduct in all interactions both on and offline.
+Please note that it's very important to us that we maintain a positive and supportive environment for everyone who wants to participate. When you join us we ask that you follow our [code of conduct] (https://github.com/BanjoFox/aardwolf/blob/master/CODE_OF_CONDUCT.md) in all interactions both on and offline.
 
 ### Contact Us
 Lately we have been hanging out on Matrix chat which is [#aardwolf-discussion:matrix.org](https://riot.im/app/#/room/#aardwolf-discussion:matrix.org), and doing almost all of our discussion there.
@@ -75,9 +75,9 @@ If you would like to get in touch with the project lead (Banjo), please checkout
 
 ### Donations
 If you like what we are doing but would prefer to provide support by keeping our coffee mugs full we have set up a LiberaPay site.
-Everyone on the core team get's an equal stake (Except for Banjo who is opting-out of donations at this time).
+Everyone on the core team gets an equal stake (Except for Banjo who is opting-out of donations at this time).
 [liberapay.com/Aardwolf](https://liberapay.com/Aardwolf)
 
 ### License
 All Aardwolf software is licensed under the GNU Affero General Public License 
-[License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](http://www.gnu.org/licenses/agpl-3.0)
+[License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)(http://www.gnu.org/licenses/agpl-3.0)


### PR DESCRIPTION
Not sure if what I did to the link for the license in line 83 is right. There was a square bracket after the link for the svg file, and it was looking strange on output on the readme file here on github. I took out that square bracket but I'm not sure if that was the right thing to do.